### PR TITLE
chore: fix justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,1 +1,9 @@
-import 'charts/deploy.just'
+import 'charts/just/mod.just'
+
+
+_default:
+    @just --list
+
+
+default_docker_tag := 'local'
+default_repo_name := 'ghcr.io/astriaorg'


### PR DESCRIPTION
Updates `justfile` with correct path to `charts/just/mod.just`, required global variables, and default recipe.